### PR TITLE
Fix Grammar and preciseness

### DIFF
--- a/git/commit.md
+++ b/git/commit.md
@@ -46,11 +46,11 @@ git commit -m "Add NEW_WALLET action to global action file and add NEW_WALLET ac
 git commit -m "Add NEW_WALLET action and action creator"
 ```
 
-### Capitalize the subject line
+### Capitalize the first letter of the first word in the subject line
 
 ```bash
 # incorrect
-git commit -m "accelerate to 88 miles per hours"
+git commit -m "accelerate to 88 miles per hour"
 ```
 
 ```bash


### PR DESCRIPTION
The incorrect capitalization git commit message example is grammatically different than the correct example. The correct example contains correct grammar. Using the correct grammar message for both examples fixes this.

The instructions regarding the capitalization of the subject line leave room for misinterpretation. Adding specificity to the instruction adds clarity.